### PR TITLE
Fix bit-rot in meta library

### DIFF
--- a/example/example.dylan
+++ b/example/example.dylan
@@ -10,15 +10,27 @@ define function digit-to-integer (x :: <character>) => (d :: <integer>)
   as(<integer>, x) - $zero;
 end function digit-to-integer;
 
-define function parse-integer (source :: <stream>);
+define generic parse-integer (source :: type-union(<stream>, <sequence>)) => (i :: false-or(<integer>));
+
+define method parse-integer (source :: <stream>) => (i :: false-or(<integer>))
   with-meta-syntax parse-stream (source)
     variables (d, sign = +1, num = 0);
     [{'+', ['-', set!(sign, -1)], []},
      test(digit?, d), set!(num, digit-to-integer(d)),
      loop([test(digit?, d), set!(num, digit-to-integer(d) + 10 * num)])];
-    sign * num;
-  end with-meta-syntax;
-end function parse-integer;
+    sign * num
+  end;
+end method;
+
+define method parse-integer (source :: <sequence>) => (i :: false-or(<integer>))
+  with-meta-syntax parse-string (source)
+    variables (d, sign = +1, num = 0);
+    [{'+', ['-', set!(sign, -1)], []},
+     test(digit?, d), set!(num, digit-to-integer(d)),
+     loop([test(digit?, d), set!(num, digit-to-integer(d) + 10 * num)])];
+    sign * num
+  end;
+end method;
 
 define function parse-finger-query (query :: <string>)
   with-collector into-buffer user like query, collect: collect;
@@ -42,12 +54,20 @@ define function test-peeking (query :: <string>)
 end function test-peeking;
 
 define method main (appname, #rest arguments)
-  format-out("Enter fixnum: ");
+  // Parse integer from stream.
+  format-out("Enter integer: ");
   force-out();
   let number = parse-integer(*standard-input*);
-  format-out("Result: %d\n", number);
+  format-out("Result: %=\n", number);
 
   read-line(*standard-input*); // parse-integer won't consume trailing garbage
+
+  // Parse integer from string.
+  format-out("Enter another integer: ");
+  force-out();
+  let string = read-line(*standard-input*);
+  let number = parse-integer(string);
+  format-out("Result: %=\n", number);
 
   format-out("Enter finger query: ");
   force-out();

--- a/example/example.dylan
+++ b/example/example.dylan
@@ -1,4 +1,3 @@
-library: example
 module: example
 
 define function digit? (x :: <character>) => (b :: <boolean>)
@@ -43,18 +42,21 @@ define function test-peeking (query :: <string>)
 end function test-peeking;
 
 define method main (appname, #rest arguments)
-  format-out("Enter fixnum: "); force-output(*standard-output*);
+  format-out("Enter fixnum: ");
+  force-out();
   let number = parse-integer(*standard-input*);
   format-out("Result: %d\n", number);
 
   read-line(*standard-input*); // parse-integer won't consume trailing garbage
 
-  format-out("Enter finger query: "); force-output(*standard-output*);
+  format-out("Enter finger query: ");
+  force-out();
   let (whois, user, at) = parse-finger-query(read-line(*standard-input*));
   format-out("Results: Whois Switch: %=, Indirect: %=, User: %=\n",
              whois, at, user);
 
-  format-out("Enter [a-z]*: "); force-output(*standard-output*);
+  format-out("Enter [a-z]*: ");
+  force-out();
   let i = test-peeking(read-line(*standard-input*));
   format-out("%= valid chars read.\n", i);
 end method main;

--- a/example/example.dylan
+++ b/example/example.dylan
@@ -1,9 +1,5 @@
 module: example
 
-define function digit? (x :: <character>) => (b :: <boolean>)
-  member?(x, "0123456789");
-end function digit?;
-
 define constant $zero = as(<integer>, '0');
 
 define function digit-to-integer (x :: <character>) => (d :: <integer>)
@@ -16,8 +12,8 @@ define method parse-integer (source :: <stream>) => (i :: false-or(<integer>))
   with-meta-syntax parse-stream (source)
     variables (d, sign = +1, num = 0);
     [{'+', ['-', set!(sign, -1)], []},
-     test(digit?, d), set!(num, digit-to-integer(d)),
-     loop([test(digit?, d), set!(num, digit-to-integer(d) + 10 * num)])];
+     test(decimal-digit?, d), set!(num, digit-to-integer(d)),
+     loop([test(decimal-digit?, d), set!(num, digit-to-integer(d) + 10 * num)])];
     sign * num
   end;
 end method;
@@ -26,8 +22,8 @@ define method parse-integer (source :: <sequence>) => (i :: false-or(<integer>))
   with-meta-syntax parse-string (source)
     variables (d, sign = +1, num = 0);
     [{'+', ['-', set!(sign, -1)], []},
-     test(digit?, d), set!(num, digit-to-integer(d)),
-     loop([test(digit?, d), set!(num, digit-to-integer(d) + 10 * num)])];
+     test(decimal-digit?, d), set!(num, digit-to-integer(d)),
+     loop([test(decimal-digit?, d), set!(num, digit-to-integer(d) + 10 * num)])];
     sign * num
   end;
 end method;

--- a/example/example.dylan
+++ b/example/example.dylan
@@ -13,7 +13,7 @@ end function digit-to-integer;
 
 define function parse-integer (source :: <stream>);
   with-meta-syntax parse-stream (source)
-    variables (d, (sign = +1), (num = 0));
+    variables (d, sign = +1, num = 0);
     [{'+', ['-', set!(sign, -1)], []},
      test(digit?, d), set!(num, digit-to-integer(d)),
      loop([test(digit?, d), set!(num, digit-to-integer(d) + 10 * num)])];
@@ -36,7 +36,7 @@ end function parse-finger-query;
 
 define function test-peeking (query :: <string>)
   with-meta-syntax parse-string (query)
-    variables (c, (i = 0));
+    variables (c, i = 0);
     loop([peeking(c, c >= 'a' & c <= 'z'), do(i := i + 1)]);
     i;
   end with-meta-syntax;

--- a/example/library.dylan
+++ b/example/library.dylan
@@ -1,12 +1,8 @@
-library: example
 module: dylan-user
 
 define library example
   use common-dylan;
-  use streams;
-  use format;
-  use format-out;
-  use standard-io;
+  use io;
   use meta;
 end library;
 

--- a/example/library.dylan
+++ b/example/library.dylan
@@ -4,6 +4,7 @@ define library example
   use common-dylan;
   use io;
   use meta;
+  use strings;
 end library;
 
 define module example
@@ -11,8 +12,9 @@ define module example
   use streams;
   use format;
   use format-out;
-  use standard-io;
   use meta;
+  use standard-io;
+  use strings;
 
   export parse-integer, parse-finger-query;
 end module;

--- a/meta-base.dylan
+++ b/meta-base.dylan
@@ -32,7 +32,7 @@ end macro with-meta-syntax;
 define macro meta-parse-aux
     { meta-parse-aux parse-stream, ?source:expression, (),
        ?meta:*,
-       ?result:expression
+       ?result:expression       // Should this be ?result:body ?
       end }
       => { let stream = ?source;
            local method match (form) => (success :: <boolean>);
@@ -42,19 +42,19 @@ define macro meta-parse-aux
                    end if;
                  end method match;
 
-          // match-type always is looking at one <character>, so
-          // it's more efficient to use rcurry(member?, seq) than
-          // instance? on singletons.  match-element fits the bill.
+           // match-type always is looking at one <character>, so
+           // it's more efficient to use rcurry(member?, seq) than
+           // instance? on singletons.  match-element fits the bill.
            local method match-type (type :: <type>)
                   => (success :: <boolean>, result :: <object>);
                    let success = instance?(peek(stream), type);
                    values(success, success & read-element(stream));
                  end method match-type;
-          local method match-element(seq :: <sequence>)
-                 => (success :: <boolean>, result :: <object>);
-                  let success = member?(peek(stream), seq);
-                  values(success, success & read-element(stream));
-                end method match-element;
+           local method match-element(seq :: <sequence>)
+                  => (success :: <boolean>, result :: <object>);
+                   let success = member?(peek(stream), seq);
+                   values(success, success & read-element(stream));
+                 end method match-element;
            local method match-test (matches? :: <function>)
                   => (success :: <boolean>, result :: <object>);
                    let success = matches?(peek(stream));

--- a/pkg.json
+++ b/pkg.json
@@ -1,0 +1,12 @@
+{
+    "name": "meta",
+    "version": "0.1.0",
+    "url": "https://github.com/dylan-lang/meta",
+    "description": "Recursive descent parser DSL",
+    "keywords": [
+        "parser"
+    ],
+    "category": "development tools",
+    "contact": "dylan-lang@googlegroups.com",
+    "dependencies": []
+}

--- a/pkg.json
+++ b/pkg.json
@@ -8,5 +8,7 @@
     ],
     "category": "development tools",
     "contact": "dylan-lang@googlegroups.com",
-    "dependencies": []
+    "dependencies": [
+        "strings@1.1"
+    ]
 }


### PR DESCRIPTION
* The example was broken.
* Add a parse-integer example that parses from a string instead of a stream.
* Use the strings library instead of rolling our own `digit?` function.
* Add a pkg.json file.